### PR TITLE
Essential updates for older Salt versions

### DIFF
--- a/eclipse-java/env.sls
+++ b/eclipse-java/env.sls
@@ -25,7 +25,7 @@ eclipse-home-alt-set:
     - name: eclipse-home
     - path: {{ eclipse.eclipse_real_home }}
     - require:
-      - eclipse-home-alt-install
+      - alternatives: eclipse-home-alt-install
 
 # Add eclipse to alternatives system
 eclipse-alt-install:
@@ -35,12 +35,12 @@ eclipse-alt-install:
     - path: {{ eclipse.eclipse_realcmd }}
     - priority: {{ eclipse.alt_priority }}
     - require:
-      - eclipse-home-alt-set
+      - alternatives: eclipse-home-alt-set
 
 eclipse-alt-set:
   alternatives.set:
     - name: eclipse
     - path: {{ eclipse.eclipse_realcmd }}
     - require:
-      - eclipse-alt-install
+      - alternatives: eclipse-alt-install
 

--- a/eclipse-java/init.sls
+++ b/eclipse-java/init.sls
@@ -51,7 +51,9 @@ eclipse-java-unpack-archive:
   {% else %}
     - options: {{ eclipse.unpack_opts }}
   {% endif %}
+  {% if grains['saltversioninfo'] >= [2016, 11, 0] %}
     - enforce_toplevel: False
+  {% endif %}
     - require:
       - cmd: eclipse-java-download-archive
 

--- a/eclipse-java/init.sls
+++ b/eclipse-java/init.sls
@@ -19,15 +19,15 @@ eclipse-java-install-dir:
 {{ archive_file }}:
   file.absent:
     - require_in:
-      - eclipse-java-download-archive
+      - file: eclipse-java-download-archive
 
 eclipse-java-download-archive:
   cmd.run:
     - name: curl {{ eclipse.dl_opts }} -o '{{ archive_file }}' '{{ eclipse.source_url }}'
     - require:
-      - eclipse-java-install-dir
+      - file: eclipse-java-install-dir
     - require_in:
-      - eclipse-java-unpacked-dir
+      - file: eclipse-java-unpacked-dir
 
 eclipse-java-unpacked-dir:
   file.directory:
@@ -37,7 +37,7 @@ eclipse-java-unpacked-dir:
     - mode: 755
     - makedirs: True
     - require_in:
-      - eclipse-java-unpack-archive
+      - file: eclipse-java-unpack-archive
 
 eclipse-java-unpack-archive:
   archive.extracted:
@@ -49,13 +49,10 @@ eclipse-java-unpack-archive:
     - archive_format: {{ eclipse.archive_type }} 
     - options: {{ eclipse.unpack_opts }}
     - enforce_toplevel: False
-    - clean: True
-    - user: root
-    - group: root
     - if_missing: {{ eclipse.eclipse_realcmd }}
     - require:
-      - eclipse-java-unpacked-dir
-      - eclipse-java-download-archive
+      - file: eclipse-java-unpacked-dir
+      - cmd: eclipse-java-download-archive
 
 eclipse-java-update-home-symlink:
   file.symlink:
@@ -63,22 +60,22 @@ eclipse-java-update-home-symlink:
     - target: {{ eclipse.eclipse_real_home }}
     - force: True
     - require:
-      - eclipse-java-unpack-archive
+      - archive: eclipse-java-unpack-archive
     - require_in:
-      - eclipse-java-remove-archive
-      - eclipse-java-remove-archive-hash
-      - eclipse-java-desktop-entry
+      - file: eclipse-java-desktop-entry
+      - file: eclipse-java-remove-archive
+      - file: eclipse-java-remove-archive-hash
 
 eclipse-java-desktop-entry:
   file.managed:
     - source: salt://eclipse-java/files/eclipse-java.desktop
     - name: /home/{{ pillar['user'] }}/Desktop/eclipse-java.desktop
     - user: {{ pillar['user'] }}
-{% if salt['grains.get']('os_family') == 'Suse' %}
+  {% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
     - group: users
-{% else %}
+  {% else %}
     - group: {{ pillar['user'] }}
-{% endif %}
+  {% endif %}
     - mode: 755
 
 eclipse-java-remove-archive:

--- a/eclipse-java/plugins.sls
+++ b/eclipse-java/plugins.sls
@@ -15,7 +15,7 @@ eclipse-extend-with-plugins-config-script:
     - group: {{ eclipse.eclipse_user }}
     - force: True
     - require:
-      - eclipse-java-update-home-symlink
+      - file: eclipse-java-update-home-symlink
     - context:
       eclipse_real_home: {{ eclipse.eclipse_real_home }}
 
@@ -25,7 +25,7 @@ eclipse-extend-with-plugins-config-execute:
     - cwd: /root
     - unless: test -f {{ eclipse.eclipse_home }}/.plugins_saltstate_done
     - require:
-      - eclipse-extend-with-plugins-config-script
+      - file: eclipse-extend-with-plugins-config-script
 
 # Add plugin preferences to workspace
 eclipse-plugin-workspace-plugin-prefs:
@@ -39,7 +39,7 @@ eclipse-plugin-workspace-plugin-prefs:
   - user: {{ eclipse.eclipse_user }}
   - group: {{ eclipse.eclipse_user }}
   - require:
-    - eclipse-extend-with-plugins-config-execute
+    - cmd: eclipse-extend-with-plugins-config-execute
 
 # if some shipped plugins need <user>, assume isimpson is hardcoded
 eclipse-plugin-replace-username-searchtags-workspace:
@@ -47,7 +47,7 @@ eclipse-plugin-replace-username-searchtags-workspace:
     - name: grep -rl isimpson {{ eclipse.workspace }} | xargs sed -i "s/isimpson/{{ eclipse.eclipse_user }}/g" 2>/dev/null
     - onlyif: test -d {{ eclipse.workspace }}
     - onchanges:
-      - eclipse-plugin-workspace-plugin-prefs
+      - file: eclipse-plugin-workspace-plugin-prefs
 
 # Setup SVN connector for Eclipse
 {%- set svn_prefs   = eclipse.metadata_plugins_dir + '/org.eclipse.core.runtime/.settings/org.eclipse.team.svn.ui.prefs' %}
@@ -59,7 +59,7 @@ eclipse-plugin-svn-connector-config:
     - text: "preference.core.svnconnector=org.eclipse.team.svn.connector.svnkit1{{ svn_version }}"
     - onlyif: test -f {{ svn_prefs }}
     - require:
-      - eclipse-plugin-workspace-plugin-prefs
+      - file: eclipse-plugin-workspace-plugin-prefs
 
 eclipse-plugin-svn-connector-dir:
   file.directory:
@@ -70,5 +70,5 @@ eclipse-plugin-svn-connector-dir:
       - user
       - group
     - require:
-      - eclipse-plugin-svn-connector-config
+      - file: eclipse-plugin-svn-connector-config
 

--- a/eclipse-java/plugins.sls
+++ b/eclipse-java/plugins.sls
@@ -1,8 +1,5 @@
 {%- from 'eclipse-java/settings.sls' import eclipse with context %}
 
-include:
-- eclipse-java
-
 # Install some favourite plugins
 eclipse-extend-with-plugins-config-script:
   file.managed:
@@ -18,8 +15,6 @@ eclipse-extend-with-plugins-config-script:
     - group: {{ eclipse.eclipse_user }}
   {% endif %}
     - force: True
-    - require:
-      - eclipse-update-home-symlink
     - context:
       eclipse_realcmd: {{ eclipse.eclipse_realcmd }}
       eclipse_real_home: {{ eclipse.eclipse_real_home }}

--- a/eclipse-java/settings.sls
+++ b/eclipse-java/settings.sls
@@ -17,12 +17,20 @@
 
 {%- set default_prefix       = '/usr/share/java' %}
 {%- set default_source_url   = mirror + '/eclipse-' + package + '-' + relname + '-' + release + arch + '.tar.gz' %}
-{%- set default_source_hash  = default_source_url + '.sha512' %}
+{%- set default_real_home    = default_prefix + '/eclipse-java-' + relname + '-' + release %}
 {%- set default_dl_opts      = ' -s ' %}
 {%- set default_archive_type = 'tar' %}
 {%- set default_symlink      = '/usr/bin/eclipse' %}
-{%- set default_realcmd      = eclipse_home + '/eclipse' %}
+{%- set default_realcmd      = default_real_home + '/eclipse' %}
 {%- set default_alt_priority = '30' %}
+{%- set default_unpack_opts  = 'z -C ' + default_real_home + ' --strip-components=1' %}
+
+{% if salt['grains.get']('saltversioninfo') <= [2016, 11, 6] %}
+   #### hash for eclipse java neon linux x64 tarball ####
+    {%- set default_source_hash  = "md5=74962bf6d674fda7da30aafdb5f6ce86" %}
+{% else %}
+    {%- set default_source_hash  = default_source_url + '.sha512' %}
+{% endif %}
 
 {%- set source_url           = g.get('source_url', p.get('source_url', default_source_url )) %}
 {%- if source_url == default_source_url %}
@@ -32,13 +40,12 @@
 {%- endif %}
 
 {%- set prefix               = g.get('prefix', p.get('prefix', default_prefix )) %}
-{%- set eclipse_real_home    = prefix + '/' + 'eclipse-java' + '-' + relname + '-' + release %}
-{%- set default_unpack_opts  = 'z -C ' + eclipse_real_home + ' --strip-components=1' %}
+{%- set eclipse_real_home    = g.get('realhome', p.get('realhome', default_real_home )) %}
 {%- set dl_opts              = g.get('dl_opts', p.get('dl_opts', default_dl_opts)) %}
+{%- set unpack_opts          = g.get('unpack_opts', p.get('unpack_opts', default_unpack_opts )) %}
 {%- set eclipse_symlink      = g.get('eclipse_symlink', p.get('eclipse_symlink', '/usr/bin/eclipse' )) %}
 {%- set eclipse_realcmd      = g.get('eclipse_realcmd', p.get('eclipse_realcmd', eclipse_home + '/eclipse' )) %}
 {%- set archive_type         = g.get('archive_type', p.get('archive_type', default_archive_type )) %}
-{%- set unpack_opts          = g.get('unpack_opts', p.get('unpack_opts', default_unpack_opts )) %}
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', default_alt_priority )) %}
 
 {%- set eclipse = {} %}


### PR DESCRIPTION
This PR addresses some shortcomings in the existing formula.

1. **Salt 2015.8.8 (Beryllium) generates "Requisite declaration XXXXXXXXXXX in SLS eclipse-java is not formed as a single key dictionary"  errors for all "requires" and "requires_in" parameter lists.**

        Solution: Prefix all requires with requisite-type (i.e. - file: eclipse-java-desktop-entry )!!

2.  **Salt 2016.3 evaluates "salt['grains.get']('os_family') == 'Suse'" as False on opensuse!!**

        Solution: Using "salt['grains.get']('os') == 'SUSE'" instead works!!

3. **Current "saltversion" check does not work on opensuse leap.**

       Solution: Twooster on #salt IRC suggested "{% if grains['saltversioninfo'] <= [2016, 11, 6] %}" which works!!

4. **Salt archive.extracted warnings that "clean: True" parameter is invalid.**

        Solution: Remove superfluous "clean: True" parameter.

5. **Salt 2016.11 archive.extracted generates "Bad state return directory" warnings. See also  https://github.com/saltstack/salt/issues/39751**

        Solution: Remove "user: root" and "group: root" from archive.extracted

6. **Salt 2016.3 on opensuse Leap complains about source_hash="https".** 

        Solution: update settings.sls to support source_hash=sha256 for older Salt.

7. **Getting warnings regarding "enforce_toplevel" in opensuse leap.**

        Solution: Enclose this parameter within  "if saltversion > 2016.11" block to resolve.

Tested successfuly (no pillars):
- Fedora 25 / Salt 2016.11.3.1.fc25
- Ubunutu 17 / Salt 2017.7.0+ds-1
- Opensuse Leap / Salt 2016.3.4.84.13