### PR TITLE
use onchanges clause; ensure hashcheck happens in older salt.

### DIFF
--- a/eclipse-java/env.sls
+++ b/eclipse-java/env.sls
@@ -24,8 +24,6 @@ eclipse-home-alt-set:
   alternatives.set:
     - name: eclipse-home
     - path: {{ eclipse.eclipse_real_home }}
-    - require:
-      - alternatives: eclipse-home-alt-install
     - onchanges:
       - alternatives: eclipse-home-alt-install
 
@@ -36,8 +34,6 @@ eclipse-alt-install:
     - link: {{ eclipse.eclipse_symlink }}
     - path: {{ eclipse.eclipse_realcmd }}
     - priority: {{ eclipse.alt_priority }}
-    - require:
-      - alternatives: eclipse-home-alt-set
     - onchanges:
       - alternatives: eclipse-home-alt-install
       - alternatives: eclipse-home-alt-set
@@ -46,8 +42,6 @@ eclipse-alt-set:
   alternatives.set:
     - name: eclipse
     - path: {{ eclipse.eclipse_realcmd }}
-    - require:
-      - alternatives: eclipse-alt-install
     - onchanges:
       - alternatives: eclipse-alt-install
 

--- a/eclipse-java/env.sls
+++ b/eclipse-java/env.sls
@@ -26,6 +26,8 @@ eclipse-home-alt-set:
     - path: {{ eclipse.eclipse_real_home }}
     - require:
       - alternatives: eclipse-home-alt-install
+    - onchanges:
+      - alternatives: eclipse-home-alt-install
 
 # Add eclipse to alternatives system
 eclipse-alt-install:
@@ -36,11 +38,16 @@ eclipse-alt-install:
     - priority: {{ eclipse.alt_priority }}
     - require:
       - alternatives: eclipse-home-alt-set
+    - onchanges:
+      - alternatives: eclipse-home-alt-install
+      - alternatives: eclipse-home-alt-set
 
 eclipse-alt-set:
   alternatives.set:
     - name: eclipse
     - path: {{ eclipse.eclipse_realcmd }}
     - require:
+      - alternatives: eclipse-alt-install
+    - onchanges:
       - alternatives: eclipse-alt-install
 

--- a/eclipse-java/files/eclipse-java.desktop
+++ b/eclipse-java/files/eclipse-java.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Name=Eclipse Java
 Comment=Eclipse for Java Developers / Modeling
-Icon=/opt/eclipse-java/icon.png
+Icon=/opt/eclipse/icon.xpm
 Exec=eclipse
 Terminal=false
 Type=Application

--- a/eclipse-java/init.sls
+++ b/eclipse-java/init.sls
@@ -37,7 +37,7 @@ eclipse-java-unpacked-dir:
     - require_in:
       - file: eclipse-java-unpack-archive
     - onchanges:
-      - file: eclipse-java-unpack-archive
+      - file: eclipse-java-download-archive
 
 eclipse-java-unpack-archive:
   archive.extracted:

--- a/eclipse-java/init.sls
+++ b/eclipse-java/init.sls
@@ -36,6 +36,8 @@ eclipse-java-unpacked-dir:
     - makedirs: True
     - require_in:
       - file: eclipse-java-unpack-archive
+    - onchanges:
+      - file: eclipse-java-unpack-archive
 
 eclipse-java-unpack-archive:
   archive.extracted:
@@ -56,6 +58,8 @@ eclipse-java-unpack-archive:
   {% endif %}
     - require:
       - cmd: eclipse-java-download-archive
+    - onchanges:
+      - cmd: eclipse-java-download-archive
 
 eclipse-java-update-home-symlink:
   file.symlink:
@@ -63,6 +67,8 @@ eclipse-java-update-home-symlink:
     - target: {{ eclipse.eclipse_real_home }}
     - force: True
     - require:
+      - archive: eclipse-java-unpack-archive
+    - onchanges:
       - archive: eclipse-java-unpack-archive
     - require_in:
       - file: eclipse-java-desktop-entry
@@ -80,15 +86,15 @@ eclipse-java-desktop-entry:
     - group: {{ pillar['user'] }}
   {% endif %}
     - mode: 755
+    - require:
+      - archive: eclipse-java-unpack-archive
+    - onchanges:
+      - archive: eclipse-java-unpack-archive
 
 eclipse-java-remove-archive:
   file.absent:
-    - name: {{ archive_file }}
-
-{%- if eclipse.source_hash %}
-eclipse-java-remove-archive-hash:
-  file.absent:
-    - name: {{ archive_file }}.sha512
-{%- endif %}
+    - names:
+      - {{ archive_file }}
+      - {{ archive_file }}.sha512
 
 {%- endif %}

--- a/eclipse-java/init.sls
+++ b/eclipse-java/init.sls
@@ -26,6 +26,8 @@ eclipse-java-download-archive:
     - name: curl {{ eclipse.dl_opts }} -o '{{ archive_file }}' '{{ eclipse.source_url }}'
     - require:
       - file: eclipse-java-remove-prev-archive
+    - require_in:
+      - file: eclipse-java-unpacked-dir
 
 eclipse-java-unpacked-dir:
   file.directory:
@@ -35,16 +37,27 @@ eclipse-java-unpacked-dir:
     - mode: 755
     - makedirs: True
     - require_in:
-      - file: eclipse-java-unpack-archive
+      - archive: eclipse-java-unpack-archive
+
+  {%- if eclipse.source_hash and grains['saltversioninfo'] <= [2016, 11, 6] %}
+    # See: https://github.com/saltstack/salt/pull/41914
+eclipse-java-check-archive-hash:
+  module.run:
+    - name: file.check_hash
+    - path: {{ archive_file }}
+    - file_hash: {{ eclipse.source_hash }}
     - onchanges:
       - cmd: eclipse-java-download-archive
+    - require_in:
+      - archive: eclipse-java-unpack-archive
+  {%- endif %}
 
 eclipse-java-unpack-archive:
   archive.extracted:
     - name: {{ eclipse.eclipse_real_home }}
     - source: file://{{ archive_file }}
     - archive_format: {{ eclipse.archive_type }} 
-  {%- if eclipse.source_hash %}
+  {%- if eclipse.source_hash and grains['saltversioninfo'] > [2016, 11, 6] %}
     - source_hash: {{ eclipse.source_hash }}
   {%- endif %}
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}
@@ -56,8 +69,6 @@ eclipse-java-unpack-archive:
   {% if grains['saltversioninfo'] >= [2016, 11, 0] %}
     - enforce_toplevel: False
   {% endif %}
-    - require:
-      - cmd: eclipse-java-download-archive
     - onchanges:
       - cmd: eclipse-java-download-archive
 
@@ -66,8 +77,6 @@ eclipse-java-update-home-symlink:
     - name: {{ eclipse.eclipse_home }}
     - target: {{ eclipse.eclipse_real_home }}
     - force: True
-    - require:
-      - archive: eclipse-java-unpack-archive
     - onchanges:
       - archive: eclipse-java-unpack-archive
     - require_in:
@@ -85,8 +94,6 @@ eclipse-java-desktop-entry:
     - group: {{ pillar['user'] }}
   {% endif %}
     - mode: 755
-    - require:
-      - archive: eclipse-java-unpack-archive
     - onchanges:
       - archive: eclipse-java-unpack-archive
 
@@ -95,5 +102,7 @@ eclipse-java-remove-archive:
     - names:
       - {{ archive_file }}
       - {{ archive_file }}.sha512
+    - onchanges:
+      - archive: eclipse-java-unpack-archive
 
 {%- endif %}

--- a/eclipse-java/init.sls
+++ b/eclipse-java/init.sls
@@ -37,7 +37,7 @@ eclipse-java-unpacked-dir:
     - require_in:
       - file: eclipse-java-unpack-archive
     - onchanges:
-      - file: eclipse-java-download-archive
+      - cmd: eclipse-java-download-archive
 
 eclipse-java-unpack-archive:
   archive.extracted:

--- a/eclipse-java/init.sls
+++ b/eclipse-java/init.sls
@@ -73,7 +73,6 @@ eclipse-java-update-home-symlink:
     - require_in:
       - file: eclipse-java-desktop-entry
       - file: eclipse-java-remove-archive
-      - file: eclipse-java-remove-archive-hash
 
 eclipse-java-desktop-entry:
   file.managed:


### PR DESCRIPTION
improvements:

(1) eclipse or eclipse.env state failure triggers unnecessary dep-states failure => use onchanges.
(2) Fix desktop icon path
(3) Ensure hashcheck happens for older salt versions.