### PR TITLE
eclipse naming change

### DIFF
--- a/eclipse/defaults.yaml
+++ b/eclipse/defaults.yaml
@@ -8,11 +8,11 @@ eclipse:
   os: linux-gtk
 
   epp:
-    uri: http://eclipse.bluemix.net/packages/
+    uri: 'http://eclipse.bluemix.net/packages/'
     home: /opt
     edition: java
-    release: oxygen
-    version: 1
+    release: 2018-09
+    version: False
 
   dl:
     archive_type: tar

--- a/eclipse/map.jinja
+++ b/eclipse/map.jinja
@@ -47,20 +47,21 @@
 {% endif %}
 
 {% do ide.epp.update({'realhome' : _realhome,
-                    'realcmd'  : _realhome ~ ide.command,
-                    'workspace': ide.homes ~ ide.prefs.user ~ ide.prefs.workspace,
-                    'metadata' : ide.homes ~ ide.prefs.user ~ ide.prefs.workspace ~ ide.plugins.path, })
-%}
+                      'realcmd'  : _realhome ~ ide.command,
+                      'workspace': ide.homes ~ ide.prefs.user ~ ide.prefs.workspace,
+                      'metadata' : ide.homes ~ ide.prefs.user ~ ide.prefs.workspace ~ ide.plugins.path, }) %}
 
-# Set release details
-{% set f = 'eclipse-{0}-{1}-{2}-{3}{4}.{5}'.format(ide.epp.edition, ide.epp.release, ide.epp.version, ide.os, ide.arch, ide.dl.suffix) %}
-{% set url  = ide.get('epp:uri', '{0}{1}/data'.format(ide.epp.uri, ide.epp.release, ide.epp.version)) ~ '/' ~ f %}
+{%- if ide.epp.version %}
+   {% set file = 'eclipse-{0}-{1}-{2}-{3}{4}.{5}'.format(ide.epp.edition, ide.epp.release, ide.epp.version, ide.os, ide.arch, ide.dl.suffix) %}
+{%- else %}
+   {% set file = 'eclipse-{0}-{1}-{2}{3}.{4}'.format(ide.epp.edition, ide.epp.release, ide.os, ide.arch, ide.dl.suffix) %}
+{%- endif %}
 
-{% do ide.dl.update({ 'archive_name': f,
+{% set url  = ide.get('epp:uri', '{0}{1}/data'.format(ide.epp.uri, ide.epp.release, ide.epp.version)) ~ '/' ~ file %}
+{% do ide.dl.update({ 'archive_name': file,
                       'src_url'     : url,
                       'src_hashurl' : url ~ '.sha512',
                       'src_hashsum' : salt['cmd.run']('curl -s {0}.sha512'.format( url )).split(' ')[0],
-                      'unpack_opts' : ' -z -C ' ~  ide.epp.realhome ~ ' --strip-components=1' })
-%}
+                      'unpack_opts' : ' -z -C ' ~  ide.epp.realhome ~ ' --strip-components=1' }) %}
 {% set eclipse = ide %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -3,8 +3,7 @@ eclipse:
     #Default uri is IBM mirror
     #editions: java,jee,cpp,committers,php,dsl,javascript,modeling,rcp,parallel,testing,scout
     edition: java
-    release: oxygen
-    version: 1
+    release: 2018-09
   dl:
     retries: 2
     interval: 30


### PR DESCRIPTION
This PR updates eclipse release to "**2018-09**" .. a new naming convention.
```
ID: eclipse-download-archive
    Function: cmd.run
        Name: curl -s -L -o '/tmp/eclipse_tmp/eclipse-java-2018-09-macosx-cocoa-x86_64.dmg' http://eclipse.bluemix.net/packages/2018-09/data/eclipse-java-2018-09-macosx-cocoa-x86_64.dmg
      Result: True
     Comment: Command "curl -s -L -o '/tmp/eclipse_tmp/eclipse-java-2018-09-macosx-cocoa-x86_64.dmg' http://eclipse.bluemix.net/packages/2018-09/data/eclipse-java-2018-09-macosx-cocoa-x86_64.dmg" run
     Started: 14:51:23.456509
    Duration: 397926.648 ms
     Changes:   
              ----------
              pid:
                  7296
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: eclipse-check-archive-hash
    Function: module.run
        Name: file.check_hash
      Result: True
     Comment: Module function file.check_hash executed
     Started: 14:58:01.385495
    Duration: 307.86 ms
     Changes:   
              ----------
              ret:
                  True
----------
          ID: eclipse-package-install
    Function: macpackage.installed
        Name: /tmp/eclipse_tmp/eclipse-java-2018-09-macosx-cocoa-x86_64.dmg
      Result: True
     Comment: Eclipse.app installed
     Started: 14:58:07.219775
    Duration: 5491.455 ms
     Changes:   
              ----------
              installed:
                  - Eclipse.app
```
