### PR TITLE
update to 2018.12

### DIFF
--- a/eclipse/defaults.yaml
+++ b/eclipse/defaults.yaml
@@ -11,7 +11,7 @@ eclipse:
     uri: 'http://eclipse.bluemix.net/packages/'
     home: /opt
     edition: java
-    release: 2018-09
+    release: 2018-12
     version: False
 
   dl:

--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,7 @@ eclipse:
     #Default uri is IBM mirror
     #editions: java,jee,cpp,committers,php,dsl,javascript,modeling,rcp,parallel,testing,scout
     edition: java
-    release: 2018-09
+    release: 2018-12
   dl:
     retries: 2
     interval: 30


### PR DESCRIPTION
Later version available.

http://eclipse.bluemix.net/packages/2018-12/data/eclipse-java-2018-12-R-macosx-cocoa-x86_64.dmg