### PR TITLE
fix(plugins): skip plugins if java not installed

### DIFF
--- a/eclipse-java
+++ b/eclipse-java
@@ -1,1 +1,0 @@
-eclipse

--- a/eclipse/files/config.sh
+++ b/eclipse/files/config.sh
@@ -4,7 +4,7 @@
 # Need a java_home
 source /etc/profile
 which java >/dev/null 2>&1
-(( $? != 0 )) && echo "java command not found. Install java and rerun eclipse-java.plugins state" && exit 112
+(( $? != 0 )) && echo "java command not found. Install java and rerun eclipse.plugins state" && exit 112
 
 ### Install popular Eclipse plugins. Should be salt-ized in future ###
 #base

--- a/eclipse/plugins.sls
+++ b/eclipse/plugins.sls
@@ -2,8 +2,8 @@
 
 # Install some favourite plugins
 
-{% if eclipse.prefs.user %}
-   {% if grains.os != 'Windows' %}
+{% if salt['cmd.run']('which java', output_loglevel='quiet') %}
+    {% if eclipse.prefs.user and grains.os != 'Windows' %}
 
 eclipse-extend-with-plugins-config-script:
   file.managed:
@@ -13,7 +13,7 @@ eclipse-extend-with-plugins-config-script:
     - makedirs: True
     - mode: 744
     - user: {{ eclipse.prefs.user }}
-      {% if eclipse.prefs.group and grains.os not in ('MacOS',) %}
+       {% if eclipse.prefs.group and grains.os not in ('MacOS',) %}
     - group: {{ eclipse.prefs.group }}
        {% endif %}
     - force: True
@@ -38,7 +38,7 @@ eclipse-plugin-workspace-plugin-prefs:
     - dir_mode: 755
     - makedirs: True
     - user: {{ eclipse.prefs.user }}
-      {% if eclipse.prefs.group and grains.os not in ('MacOS',) %}
+       {% if eclipse.prefs.group and grains.os not in ('MacOS',) %}
     - group: {{ eclipse.prefs.group }}
        {% endif %}
     - onchanges:
@@ -83,5 +83,14 @@ eclipse-plugin-svn-connector-dir:
 
       {% endif %}
 
-  {% endif %}
+    {% endif %}
+{% else %}
+
+eclipse-no-java-notification:
+  test.show_notification:
+    - text: |
+        Skipping eclipse.plugins state.
+        java command not found.
+        Install java and rerun eclipse.plugins state
+
 {% endif %}


### PR DESCRIPTION
Resolves #26 
Verified on Ubuntu with no java installed
```
vagrant@ubuntu1804:~$ sudo salt-call state.highstate --local
local:
----------
          ID: eclipse-no-java-notification
    Function: test.show_notification
      Result: True
     Comment: Skipping eclipse.plugins state.
              java command not found.
              Install java and rerun eclipse.plugins state
     Started: 13:50:06.594549
    Duration: 0.566 ms
     Changes:   

Summary for local
------------
Succeeded: 1
Failed:    0
------------
```